### PR TITLE
🔀 Switch to Docker Hub Chainguard Images

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "good-repo-poc",
+  "name": "good-repo",
   "image": "ghcr.io/ministryofjustice/devcontainer-base:latest",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},

--- a/Containerfile
+++ b/Containerfile
@@ -1,12 +1,18 @@
 ##################################################
-# Stage: Build
+# Stage: uv
+# From: ghcr.io/astral-sh/uv:python3.13-alpine
+##################################################
+FROM ghcr.io/astral-sh/uv:python3.13-alpine@sha256:d911044652e6f56d74ee0c68c4aced000cc51cc3cef4f56ace668d88d3e7e5f2 AS uv
+
+##################################################
+# Stage: builder
 # From: docker.io/chainguard/python:latest-dev
 ##################################################
 FROM docker.io/chainguard/python:latest-dev@sha256:83368419da958ef8f7b049c1dc52238a77a8daa2ed1f264e2fb8444bc9f82b06 AS builder
 
 WORKDIR /app
 
-COPY --from=ghcr.io/astral-sh/uv:python3.13-alpine /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uv
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
@@ -14,7 +20,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-install-project --no-editable --no-dev
 
 ##################################################
-# Stage: Final
+# Stage: final
 # From: docker.io/chainguard/python:latest
 ##################################################
 FROM docker.io/chainguard/python:latest@sha256:0ed9f745adb1df1131a46e89945bde7117eadde7b904c74188ec81df3f488c2b AS final

--- a/Containerfile
+++ b/Containerfile
@@ -1,12 +1,12 @@
 ##################################################
 # Stage: Build
-# From: cgr.dev/chainguard/python:latest-dev
+# From: docker.io/chainguard/python:latest-dev
 ##################################################
-FROM cgr.dev/chainguard/python:latest-dev@sha256:83368419da958ef8f7b049c1dc52238a77a8daa2ed1f264e2fb8444bc9f82b06 AS builder
+FROM docker.io/chainguard/python:latest-dev@sha256:83368419da958ef8f7b049c1dc52238a77a8daa2ed1f264e2fb8444bc9f82b06 AS builder
 
 WORKDIR /app
 
-COPY --from=ghcr.io/astral-sh/uv:python3.13-alpine@sha256:d911044652e6f56d74ee0c68c4aced000cc51cc3cef4f56ace668d88d3e7e5f2 /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:python3.13-alpine /usr/local/bin/uv /usr/local/bin/uv
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
@@ -15,9 +15,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 ##################################################
 # Stage: Final
-# From: cgr.dev/chainguard/python:latest
+# From: docker.io/chainguard/python:latest
 ##################################################
-FROM cgr.dev/chainguard/python:latest@sha256:0ed9f745adb1df1131a46e89945bde7117eadde7b904c74188ec81df3f488c2b AS final
+FROM docker.io/chainguard/python:latest@sha256:0ed9f745adb1df1131a46e89945bde7117eadde7b904c74188ec81df3f488c2b AS final
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# good-repo-poc
+# Good Repo
 
 > An _opinionated_ approach of a "good" repository.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Good Repo
+# Good Repository
 
 > An _opinionated_ approach of a "good" repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "good-repo-poc"
+name = "good-repo"
 version = "0.0.1"
 description = "Proof of Concept of a good repository"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 ]
 
 [[package]]
-name = "good-repo-poc"
+name = "good-repo"
 version = "0.0.1"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
## Proposed Changes

- Switches to `docker.io/chainguard/python` in the hopes that Dependabot can actually read the API, and its not that Dependabot doesn't support multistage Dockerfiles
- Removes PoC suffix

Signed-off-by: Jacob Woffenden <jacob@woffenden.io>