### PR TITLE
🏔️ Switch to Python Alpine base

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,9 +6,9 @@ FROM ghcr.io/astral-sh/uv:python3.13-alpine@sha256:d911044652e6f56d74ee0c68c4ace
 
 ##################################################
 # Stage: builder
-# From: docker.io/chainguard/python:latest-dev
+# From: docker.io/python:3.13-alpine3.21
 ##################################################
-FROM docker.io/chainguard/python:latest-dev@sha256:83368419da958ef8f7b049c1dc52238a77a8daa2ed1f264e2fb8444bc9f82b06 AS builder
+FROM docker.io/python:3.13-alpine3.21@sha256:452682e4648deafe431ad2f2391d726d7c52f0ff291be8bd4074b10379bb89ff AS builder
 
 WORKDIR /app
 
@@ -17,17 +17,41 @@ COPY --from=uv /usr/local/bin/uv /usr/local/bin/uv
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project --no-editable --no-dev
+<<EOF
+uv sync --locked --no-install-project --no-editable --no-dev
+EOF
 
 ##################################################
 # Stage: final
-# From: docker.io/chainguard/python:latest
+# From: docker.io/python:3.13-alpine3.21
 ##################################################
-FROM docker.io/chainguard/python:latest@sha256:0ed9f745adb1df1131a46e89945bde7117eadde7b904c74188ec81df3f488c2b AS final
+FROM docker.io/python:3.13-alpine3.21@sha256:452682e4648deafe431ad2f2391d726d7c52f0ff291be8bd4074b10379bb89ff AS final
 
-WORKDIR /app
+LABEL org.opencontainers.image.vendor="Woffenden" \
+      org.opencontainers.image.authors="Platform Engineering (platform-engineering@woffenden.io)" \
+      org.opencontainers.image.title="good-repo" \
+      org.opencontainers.image.description="An opinionated approach of a good repository" \
+      org.opencontainers.image.url="https://github.com/woffenden/good-repo"
 
-COPY --from=builder /app/.venv /app/.venv
-COPY app/ /app
+ENV CONTAINER_USER="nonroot" \
+    CONTAINER_UID="65532" \
+    CONTAINER_GROUP="nonroot" \
+    CONTAINER_GID="65532" \
+    APP_HOME="/app" \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:${PATH}"
 
-ENTRYPOINT ["/app/.venv/bin/python", "main.py"]
+RUN <<EOF
+adduser -D -u ${CONTAINER_UID} -g ${CONTAINER_GID} ${CONTAINER_USER}
+
+install --directory --mode=0755 --owner="${CONTAINER_USER}" --group="${CONTAINER_GROUP}" "${APP_HOME}"
+EOF
+
+WORKDIR ${APP_HOME}
+COPY --from=builder --chown=${CONTAINER_UID}:${CONTAINER_GID} /app/.venv /app/.venv
+COPY --chown=${CONTAINER_UID}:${CONTAINER_GID} app/ /app
+
+USER ${CONTAINER_UID}
+
+EXPOSE 8080
+ENTRYPOINT ["python", "main.py"]


### PR DESCRIPTION
## Proposed Changes

- Switches to `docker.io/python:3.13-alpine3.21`
  - I _think_ using Chainguard's `python:latest` and `python:latest-dev` broke Dependabot
- Extends `docker.io/python:3.13-alpine3.21` in `final` stage to be "nonroot"

Signed-off-by: Jacob Woffenden <jacob@woffenden.io>